### PR TITLE
fix the issue when mouse leave from quality button the quality selector does not hidden

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -171,6 +171,7 @@ Object.assign(MediaElementPlayer.prototype, {
 						media.pause();
 						media.setSrc(src.src);
 						media.load();
+            media.dispatchEvent(mejs.Utils.createEvent('seeking', media));
 						media.addEventListener('canplay', canPlayAfterSourceSwitchHandler);
 					}
 				}

--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -121,8 +121,8 @@ Object.assign(MediaElementPlayer.prototype, {
 		}
 
 		for (let i = 0, total = outEvents.length; i < total; i++) {
-			selector.addEventListener(outEvents[i], function () {
-				mejs.Utils.addClass(this, `${t.options.classPrefix}offscreen`);
+      player.qualitiesButton.addEventListener(outEvents[i], function () {
+				mejs.Utils.addClass(selector, `${t.options.classPrefix}offscreen`);
 			});
 		}
 


### PR DESCRIPTION
Because `outEvents` were bound to `.qualities-selector`, so if user move mouse leave from quality button, the selector was still there.

So I replace `selector` with `player`. 