### PR TITLE
Fix quality title text pulling from the wrong i18n

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -62,7 +62,7 @@ Object.assign(MediaElementPlayer.prototype, {
 		t.cleanquality(player);
 
 		const
-			qualityTitle = mejs.Utils.isString(t.options.qualityText) ? t.options.qualityText : mejs.i18n.t('mejs.quality-quality'),
+			qualityTitle = mejs.Utils.isString(t.options.qualityText) ? t.options.qualityText : mejs.i18n.t('mejs.quality-chooser'),
 			getQualityNameFromValue = (value) => {
 				let label;
 				if (value === 'auto') {


### PR DESCRIPTION
`mejs.quality-quality` is not defined anywhere else and `mejs.quality-choose` is left unused, leaving the quality text with a bogus default value.