### PR TITLE
Adding 'mejsprerollfinished' Event to Ads.js

### DIFF
--- a/src/ads/ads.js
+++ b/src/ads/ads.js
@@ -279,6 +279,8 @@ Object.assign(MediaElementPlayer.prototype, {
 			if (t.options.indexPreroll < t.options.adsPrerollMediaUrl.length) {
 				t.adsStartPreroll();
 			} else {
+				const event = mejs.Utils.createEvent('mejsprerollfinished', t.container);
+     		t.container.dispatchEvent(event);
 				t.adRestoreMainMedia();
 			}
 
@@ -360,6 +362,10 @@ Object.assign(MediaElementPlayer.prototype, {
 		if (t.options.indexPreroll < t.options.adsPrerollMediaUrl.length) {
 			t.adsStartPreroll();
 		} else {
+			
+			event = mejs.Utils.createEvent('mejsprerollfinished', t.container);
+			t.container.dispatchEvent(event);
+			
 			t.adRestoreMainMedia();
 		}
 

--- a/src/ads/ads.js
+++ b/src/ads/ads.js
@@ -280,7 +280,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				t.adsStartPreroll();
 			} else {
 				const event = mejs.Utils.createEvent('mejsprerollfinished', t.container);
-     		t.container.dispatchEvent(event);
+				t.container.dispatchEvent(event);
 				t.adRestoreMainMedia();
 			}
 


### PR DESCRIPTION
Adding an Event to detect that all prerolls have finished playing should simplify Tasks like adding overlays only to the Main-Video.

Code Example
```js
const player = new MediaElementPlayer('IdSelector', options);
$(player.container).on('mejsprerollfinished', () => {
     addOverlaysFunction()
 })
```
If there is already a best-practice to detect that prerolls did finsish, this change becomes uneccesary.
Also please let me know, as I could not find an elegant solution prior.