### PR TITLE
focusout event timeout

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -133,7 +133,9 @@ Object.assign(MediaElementPlayer.prototype, {
 
 		for (let i = 0, total = outEvents.length; i < total; i++) {
 			player.qualitiesButton.addEventListener(outEvents[i], () => {
-				mejs.Utils.addClass(selector, `${t.options.classPrefix}offscreen`);
+				setTimeout(() => {
+					mejs.Utils.addClass(selector, `${t.options.classPrefix}offscreen`);
+				}, 50);
 			});
 		}
 


### PR DESCRIPTION
Focusout event triggered, hiding element (by adding offscreen class). After - triggered click event, but there is no visible label element.

Applicable for android devices.