### PR TITLE
Add Markers Rolls plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function (grunt) {
 					'dist/speed/speed.js': 'src/speed/speed.js',
 					'dist/stop/stop.js': 'src/stop/stop.js',
 					'dist/vrview/vrview.js': 'src/vrview/vrview.js',
+					'dist/markersrolls/markersrolls.js': 'src/markersrolls/markersrolls.js',
 				},
 				options: {
 					plugin: [

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ See`src/` directory, and check how the files were written to ensure compatibilit
 * [Jump Forward](docs/jump-forward.md)
 * [Loop](docs/loop.md)
 * [Markers](docs/markers.md)
+* [Markers Rolls](docs/markersrolls.md)
 * [Playlist](docs/playlist.md)
 * [Postroll](docs/postroll.md)
 * [Preview](docs/preview.md)

--- a/demo/markersrolls.html
+++ b/demo/markersrolls.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>MediaElement.js 3.0 - Markers Plugin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/4.2.6/mediaelementplayer.css">
+    <link rel="stylesheet" href="demo.css">
+</head>
+<body>
+<div id="container">
+
+    <h1>Markers Rolls Plugin</h1>
+    <p><a href="index.html">Back to Main</a></p>
+
+    <p>Based in Markers and Postroll plugins.</p>
+
+    <p>
+        This plugin allows you to create Visual Cues in the progress time rail and inject HTML content in these markers.
+        The HTML content will be displayed every time the media reaches a marker.
+    </p>
+
+    <p>Every marker answer to a URL to inject the content in the video player when the marker position is reached.</p>
+
+    <p>Color for markers are configurable.</p>
+
+    <h2>Video Player</h2>
+
+    <div class="media-wrapper">
+        <video id="player1" width="750" height="421" controls preload="none">
+            <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/mp4/BigBuckBunny.mp4"
+                    type="video/mp4">
+        </video>
+    </div>
+
+    <h2>API</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Type</th>
+                <th>Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>markersRollsColor</td>
+                <td>string</td>
+                <td>#E9BC3D</td>
+                <td> Specify the color of marker in hexadecimal code</td>
+            </tr>
+            <tr>
+                <td>markersRollsWidth</td>
+                <td>number</td>
+                <td>1</td>
+                <td>Specify the width of marker in pixels</td>
+            </tr>
+            <tr>
+                <td>markersRolls</td>
+                <td>object</td>
+                <td>{}</td>
+                <td>List of markers. Specifying the time in seconds and an URL to show.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/4.2.6/mediaelement-and-player.min.js"></script>
+<script src="../dist/markersrolls/markersrolls.js"></script>
+<script>
+	var mediaElements = document.querySelectorAll('video, audio');
+
+	for (var i = 0, total = mediaElements.length; i < total; i++) {
+		new MediaElementPlayer(mediaElements[i], {
+            markersRolls: {
+			    3: 'http://localhost/mediaelement-plugins/demo/end.html',
+                10: 'http://localhost/mediaelement-plugins/demo/index.html',
+                45: 'http://localhost/mediaelement-plugins/demo/end.html',
+                360: 'http://localhost/mediaelement-plugins/demo/index.html'
+            },
+			features: ['playpause', 'current', 'progress', 'duration', 'volume', 'fullscreen', 'markersrolls'],
+		});
+	}
+</script>
+</body>
+</html>

--- a/docs/markersrolls.md
+++ b/docs/markersrolls.md
@@ -1,0 +1,25 @@
+# Markers
+
+## Overview
+
+Based in Markers and Postroll plugins.
+
+This plugin allows you to create Visual Cues in the progress time rail and inject HTML content in these markers.
+The HTML content will be displayed every time the media reaches a marker.
+
+Every marker answer to a URL to inject the content in the video player when the marker position is reached.
+
+Color for markers are configurable.
+
+## Keyword to use it
+```javascript
+features: [..., 'markersrolls']
+```
+
+## API
+
+Parameter | Type | Default | Description
+------ | --------- | ------- | --------
+markersRollsColor | string | `#E9BC3D` | Specify the color of markers in hexadecimal code
+markersRollsWidth | number | `1` | Specify the width of markers in pixels
+markersRolls | object | `{}` | Marker times in seconds associated to the URL to inject. See demo folder for examples.

--- a/src/markersrolls/markersrolls.js
+++ b/src/markersrolls/markersrolls.js
@@ -1,0 +1,138 @@
+'use strict';
+
+/**
+ * Markers Rolls plugin
+ *
+ * Based in Markers and Postroll plugins.
+ *
+ * This plugin allows you to add Visual Cues in the progress time rail and inject HTML content in these markers.
+ * Every marker answer to a URL to inject the content in the video player when the marker position is reached.
+ * Color for markers are configurable.
+ */
+
+// Feature configuration
+Object.assign(mejs.MepDefaults, {
+	/**
+	 * Default marker color
+	 * @type {String}
+	 */
+	markersRollsColor: '#E9BC3D',
+	/**
+	 * Default marker width
+	 * @type {Number}
+	 */
+	markersRollsWidth: 1,
+	/**
+	 * @type {Object}
+	 */
+	markersRolls: {}
+});
+
+Object.assign(MediaElementPlayer.prototype, {
+	/**
+	 * Feature constructor.
+	 *
+	 * Always has to be prefixed with `build` and the name that will be used in MepDefaults.features list.
+	 *
+	 * @param {MediaElementPlayer} player
+	 * @param {HTMLElement} controls
+	 * @param {HTMLElement} layers
+	 * @param {HTMLElement} media
+	 */
+	buildmarkersrolls (player, controls, layers, media)  {
+		let currentPosition = -1,
+			lastPlayedPosition = -1, // Track backward seek
+			lastMarkerRollCallback = -1, // Prevents successive firing of callbacks
+			markersCount = Object.keys(player.options.markersRolls).length;
+
+		if (!markersCount) {
+			return;
+		}
+
+		for (let i = 0, total = markersCount; i < total; ++i) {
+			const marker = document.createElement('span');
+
+			marker.className = `${this.options.classPrefix}time-marker`;
+			controls.querySelector(`.${this.options.classPrefix}time-total`).appendChild(marker);
+		}
+
+		let markersRollsLayer = document.createElement('iframe');
+		markersRollsLayer.frameBorder = '0';
+        markersRollsLayer.className = `${this.options.classPrefix}markersrolls-layer` + ' '
+			+ `${this.options.classPrefix}overlay` + ' '
+			+ `${this.options.classPrefix}layer`;
+        markersRollsLayer.style.display = 'none';
+        markersRollsLayer.style.backgroundColor = '#9F9F9F';
+        markersRollsLayer.style.border = '0 none';
+        markersRollsLayer.style.boxShadow = '#B0B0B0 0px 0px 20px -10px inset';
+		markersRollsLayer.style.paddingBottom = '40px';
+
+        layers.appendChild(markersRollsLayer);
+
+		media.addEventListener('durationchange', () => {
+			player.setmarkersrolls(controls);
+		});
+		media.addEventListener('timeupdate', () => {
+			currentPosition = Math.floor(media.currentTime);
+
+			if (lastPlayedPosition > currentPosition) {
+				if (lastMarkerRollCallback > currentPosition) {
+					lastMarkerRollCallback = -1;
+				}
+			} else {
+				lastPlayedPosition = currentPosition;
+			}
+
+			if (0 === markersCount ||
+				!player.options.markersRolls[currentPosition] ||
+				currentPosition === lastMarkerRollCallback
+			) {
+				return;
+			}
+
+			lastMarkerRollCallback = currentPosition;
+
+			media.pause();
+
+            markersRollsLayer.src = player.options.markersRolls[currentPosition];
+            markersRollsLayer.style.display = 'block';
+		}, false);
+		media.addEventListener('play', () => {
+			markersRollsLayer.style.display = 'none';
+			markersRollsLayer.src = '';
+		}, false);
+
+	},
+
+	/**
+	 * Create markers in the progress bar.
+	 *
+	 * @param {HTMLElement} controls
+	 */
+	setmarkersrolls (controls)  {
+		const markersRolls = controls.querySelectorAll(`.${this.options.classPrefix}time-marker`);
+
+		let i = 0;
+
+		for (let position in this.options.markersRolls) {
+			if (!this.options.markersRolls.hasOwnProperty(position)) {
+				continue;
+            }
+
+			position = parseInt(position);
+
+			if (position >= this.media.duration || position < 0) {
+				continue;
+			}
+
+			const left = 100 * position / this.media.duration,
+				marker = markersRolls[i];
+
+			marker.style.width = this.options.markersRollsWidth + 'px';
+			marker.style.left = `${left}%`;
+			marker.style.background = this.options.markersRollsColor;
+
+			i++;
+		}
+	}
+});


### PR DESCRIPTION
Based in Markers and Postroll plugins.

This plugin allows you to create Visual Cues in the progress time rail and inject HTML content in these markers.
The HTML content will be displayed every time the media reaches a marker.

Every marker answer to a URL to inject the content in the video player when the marker position is reached.

Color for markers are configurable.