### PR TITLE
close postroll, when replaing video

### DIFF
--- a/src/postroll/postroll.js
+++ b/src/postroll/postroll.js
@@ -57,6 +57,14 @@ Object.assign(MediaElementPlayer.prototype, {
 				});
 				player.postroll.style.display = 'block';
 			}, false);
+
+			t.media.addEventListener('seeked', () => {
+				player.postroll.style.display = 'none';
+			}, false);
+
+			t.media.addEventListener('playing', () => {
+				player.postroll.style.display = 'none';
+			}, false);
 		}
 	}
 });


### PR DESCRIPTION
When user click replay, after showed postroll we need to hide postroll.