### PR TITLE
Patch for open issue #129

### DIFF
--- a/src/playlist/playlist.js
+++ b/src/playlist/playlist.js
@@ -348,12 +348,13 @@ Object.assign(MediaElementPlayer.prototype, {
 	},
 
 	createPlayList_ () {
-		const t = this;
+    		const t = this;
 
-		t.playlist = t.options.playlist.length ? t.options.playlist : [];
+		t.playlist = t.options.playlist.length ? t.options.playlist : 
+			t.mediaFiles && t.mediaFiles.length ? t.mediaFiles : [];
 
 		if (!t.playlist.length) {
-			const children = t.mediaFiles || t.media.originalNode.children;
+			const children = t.media.originalNode.children;
 
 			for (let i = 0, total = children.length; i < total; i++) {
 				const childNode = children[i];


### PR DESCRIPTION
This addresses the open issue #129 

https://github.com/mediaelement/mediaelement-plugins/issues/129

When `t.mediaFiles` is defined, its an Array of Objects, not an NodeList of Nodes so iterating over them and calling `.tagName` on the Object will always raise an exception.  This occurs in Safari because of a subroutine in `mediaelement-and-player.js` (4.2.8 but even latest) that does this:

```
				if (_constants.IS_SAFARI && !_constants.IS_IOS) {

					dom.addClass(t.getElement(t.container), t.options.classPrefix + 'hide-cues');

					var cloneNode = t.node.cloneNode(),
					    children = t.node.children,
					    mediaFiles = [],
					    tracks = [];

					for (var i = 0, total = children.length; i < total; i++) {
						var childNode = children[i];

						(function () {
							switch (childNode.tagName.toLowerCase()) {
								case 'source':
									var elements = {};
									Array.prototype.slice.call(childNode.attributes).forEach(function (item) {
										elements[item.name] = item.value;
									});
									elements.type = (0, _media.formatType)(elements.src, elements.type);
									mediaFiles.push(elements);
									break;
```

In any case, t.mediaFiles should not be treated as a list of nodes, its not.  Thank you!