### PR TITLE
source-chooser: fix "TypeError: filter is not a function" exception

### DIFF
--- a/src/source-chooser/source-chooser.js
+++ b/src/source-chooser/source-chooser.js
@@ -168,7 +168,11 @@ Object.assign(MediaElementPlayer.prototype, {
 
 		// Handle click so that screen readers can toggle the menu
 		player.sourcechooserButton.querySelector('button').addEventListener('click', function() {
-			if (mejs.Utils.hasClass(mejs.Utils.siblings(this, `.${t.options.classPrefix}sourcechooser-selector`), `${t.options.classPrefix}offscreen`)) {
+			var sourcechooser = mejs.Utils.siblings(this, function(el) {
+				return mejs.Utils.hasClass(el, `${t.options.classPrefix}sourcechooser-selector`);
+			})[0];
+
+			if (mejs.Utils.hasClass(sourcechooser, `${t.options.classPrefix}offscreen`)) {
 				player.showSourcechooserSelector();
 				player.sourcechooserButton.querySelector('input[type=radio]:checked').focus();
 			} else {


### PR DESCRIPTION
When clicking the source chooser button a "TypeError: filter is not a function"
error message appears in the console.

This error appears to be caused by the conversion of mejs.Utils away from jQuery
which used to allow mejs.Utils.siblings() to take a class selector string: the
current implementation requires the second parameter to be a filter function.