### PR TITLE
Fix key action "slower" jumps to lowest speed

### DIFF
--- a/src/speed/speed.js
+++ b/src/speed/speed.js
@@ -206,6 +206,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					if (radios[i].checked) {
 						const nextRadio = radios[i+1];
 						nextRadio.dispatchEvent(mejs.Utils.createEvent('click', nextRadio));
+						break;
 					}
 				}
 			}
@@ -219,6 +220,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					if (radios[i].checked) {
 						const prevRadio = radios[i-1];
 						prevRadio.dispatchEvent(mejs.Utils.createEvent('click', prevRadio));
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
Hitting `<` jumps to lowest speed, not to next lower speed as expected. This PR fixes that.