### PR TITLE
Fixing playlist behavior when track ends

### DIFF
--- a/src/playlist/playlist.js
+++ b/src/playlist/playlist.js
@@ -80,8 +80,8 @@ Object.assign(MediaElementPlayer.prototype, {
 		controls.style.zIndex = 5;
 
 		player.endedCallback = () => {
-			if (player.currentPlaylistItem < player.listItems.length) {
-				player.setSrc(player.playlist[++player.currentPlaylistItem]);
+			if (player.currentPlaylistItem < player.listItems.length - 1) {
+				player.setSrc(player.playlist[++player.currentPlaylistItem].src);
 				player.load();
 				setTimeout(() => {
 					player.play();


### PR DESCRIPTION
This should both fix the issues https://github.com/mediaelement/mediaelement-plugins/issues/225 and https://github.com/mediaelement/mediaelement-plugins/issues/223

Means it properly detects the end of the playlist (since the `currentPlaylistItem` starts with `0`) and it properly sets the Source-URL of the PlaylistItem, and not the whole object as new player source (same as it is done for prev/next buttons).