### PR TITLE
Update Aktion Mensch demo assets urls

### DIFF
--- a/demo/a11y.html
+++ b/demo/a11y.html
@@ -20,12 +20,12 @@
         <h2>Video Player (w/o Voice-Over)</h2>
         <div class="media-wrapper">
             <video id="player1" width="750" height="421" controls preload="none" playsinline
-                   data-video-description='[{"src": "https://video.aktion-mensch.de/magnolia/aktion-mensch-videoplayer/aktion-mensch_beispiel/aktion-mensch_beispiel_signlanguageVideo.mp4", "type": "video/mp4"}, {"src": "https://video.aktion-mensch.de/magnolia/aktion-mensch-videoplayer/aktion-mensch_beispiel/aktion-mensch_beispiel_signlanguageVideo.webm", "type": "video/webm"}, {"src": "https://video.aktion-mensch.de/magnolia/aktion-mensch-videoplayer/aktion-mensch_beispiel/aktion-mensch_beispiel_signlanguageVideo.ogv", "type": "video/ogv"}]'
-                   data-audio-description='[{"src": "https://video.aktion-mensch.de/magnolia/aktion-mensch_beispiel_audioDescription.mp3", "type": "audio/mp3"}]'
+                   data-video-description='[{"src": "https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_signlanguageVideo.mp4", "type": "video/mp4"}, {"src": "https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_signlanguageVideo.webm", "type": "video/webm"}, {"src": "https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_signlanguageVideo.ogv", "type": "video/ogv"}]'
+                   data-audio-description='[{"src": "https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_audioDescription.mp3", "type": "audio/mp3"}]'
             >
-                <source src="https://video.aktion-mensch.de/magnolia/aktion-mensch_beispiel_video.mp4" type="video/mp4" />
-                <source src="https://video.aktion-mensch.de/magnolia/aktion-mensch_beispiel_video.webm" type="video/webm" />
-                <source src="https://video.aktion-mensch.de/magnolia/aktion-mensch_beispiel_video.ogv" type="video/ogg" />
+                <source src="https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_video.mp4" type="video/mp4" />
+                <source src="https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_video.webm" type="video/webm" />
+                <source src="https://aktion-mensch.stylelabs.cloud/api/public/content/aktion-mensch_beispiel_video.ogv" type="video/ogg" />
             </video>
         </div>
     </div>


### PR DESCRIPTION
The location of the demo assets supplied by Aktion Mensch have changed, this pull request updates their urls inside the demo file: `demo/a11y.html`