### PR TITLE
Add the attributes role="radiogroup" and aria-labelledby for speed-button

### DIFF
--- a/src/speed/speed.js
+++ b/src/speed/speed.js
@@ -107,10 +107,11 @@ Object.assign(MediaElementPlayer.prototype, {
 
 		player.speedButton = document.createElement('div');
 		player.speedButton.className = `${t.options.classPrefix}button ${t.options.classPrefix}speed-button`;
+		player.speedButton.id = `speed-button-${Math.random()}`;
 		player.speedButton.innerHTML = `<button type="button" aria-controls="${t.id}" title="${speedTitle}" ` +
 			`aria-label="${speedTitle}" tabindex="0">${getSpeedNameFromValue(t.options.defaultSpeed)}</button>` +
 			`<div class="${t.options.classPrefix}speed-selector ${t.options.classPrefix}offscreen">` +
-				`<ul class="${t.options.classPrefix}speed-selector-list"></ul>` +
+				`<ul class="${t.options.classPrefix}speed-selector-list" role="radiogroup" aria-labelledby="${player.speedButton.id}"></ul>` +
 			`</div>`;
 
 		t.addControlElement(player.speedButton, 'speed');


### PR DESCRIPTION
Hello,
I would like to provide additional features for the speed plugin to group the radio inputs in a radio group, according to https://w3c.github.io/aria/#radiogroup.

Thank you very much for your efforts.