### PR TITLE
The cleanMediaSource function was updated

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -343,9 +343,10 @@ Object.assign(MediaElementPlayer.prototype, {
 		for (let i = 0; i < media.children.length; i++) {
 			let mediaNode = media.children[i];
 			if (mediaNode.tagName === 'VIDEO') {
-				while (mediaNode.firstChild) {
-					mediaNode.removeChild(mediaNode.firstChild);
-				}
+				const sourceNodes = mediaNode.querySelectorAll('source');
+				Array.from(sourceNodes).forEach((sourceNode) => {
+					mediaNode.removeChild(sourceNode);
+				});
 			}
 		}
 	},


### PR DESCRIPTION
The `cleanMediaSource` function was updated to prevent captions (or any other content within the `video` tag) from being deleted when the quality of video is changed. Only the `source` will be replaced as intended.