### PR TITLE
Add option hslQualityChangeStrategy and change default qualityStrategy to nextLevel ( from currentLevel )

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -25,6 +25,10 @@ Object.assign(mejs.MepDefaults, {
 	 */
 	autoGenerate: false,
 	/**
+	 * @type {String}
+	 */
+	hslQualityChangeStrategy: 'nextLevel',
+	/**
 	 * @type {boolean}
 	 */
 	autoDash: false,
@@ -415,13 +419,14 @@ Object.assign(MediaElementPlayer.prototype, {
 	 * @param {MediaElement} media
 	 */
 	switchHLSQuality (player, media) {
+		const t = this;
 		const radios = player.qualitiesContainer.querySelectorAll('input[type="radio"]');
 		for (let index = 0; index < radios.length; index++) {
 			if (radios[index].checked) {
 				if (index === 0 ) {
-					media.hlsPlayer.currentLevel = -1;
+					media.hlsPlayer[t.options.hslQualityChangeStrategy] = -1;
 				} else {
-					media.hlsPlayer.currentLevel = index - 1;
+					media.hlsPlayer[t.options.hslQualityChangeStrategy] = index - 1;
 				}
 			}
 		}


### PR DESCRIPTION
Add option hslQualityChangeStrategy.

Set option to nextLevel instead of currentLevel. 
This means that the next fragment will load with the set quality instead of the current. 
This results in smoother playback when compared to currentLevel
