### PR TITLE
Fix an issue in Quality where the initial button press does not work on a touch device

### DIFF
--- a/src/quality/quality.js
+++ b/src/quality/quality.js
@@ -194,7 +194,15 @@ Object.assign(MediaElementPlayer.prototype, {
 			labels = player.qualitiesContainer.querySelectorAll(`.${t.options.classPrefix}qualities-selector-label`)
 		;
 
+		let lastShowChange = Date.now();
 		function hideSelector() {
+			const now = Date.now();
+			const diff = now - lastShowChange;
+			if(diff < 16) {
+				return;
+			}
+			lastShowChange = now;
+			
 			mejs.Utils.addClass(qualitiesSelector, `${t.options.classPrefix}offscreen`);
 			qualityButton.setAttribute('aria-expanded', 'false');
 			qualityButton.focus();
@@ -202,6 +210,13 @@ Object.assign(MediaElementPlayer.prototype, {
 		}
 
 		function showSelector() {
+			const now = Date.now();
+			const diff = now - lastShowChange;
+			if(diff < 16) {
+				return;
+			}
+			lastShowChange = now;
+			
 			mejs.Utils.removeClass(qualitiesSelector, `${t.options.classPrefix}offscreen`);
 			qualitiesSelector.style.height = `${qualitiesSelector.querySelector('ul').offsetHeight}px`;
 			qualitiesSelector.style.top = `${(-1 * parseFloat(qualitiesSelector.offsetHeight))}px`;


### PR DESCRIPTION
Tested with: chromebook in touch mode, 

The problem:
Due to the fact that the mouseenter event gets triggered when you click the button,
causing both mouseevent and click event to trigger right after each other, 
making the click cancel out the touchenter event.

This pull request fixes the issue by keeping track of when the last call to hideSelector or showSelector happened, 
and rejecting it when the time between the last one and the current one is less than 16 milliseconds ago.