### PR TITLE
Fix endedCallback to use sources correctly and not to read after last index

### DIFF
--- a/src/playlist/playlist.js
+++ b/src/playlist/playlist.js
@@ -80,12 +80,14 @@ Object.assign(MediaElementPlayer.prototype, {
 		controls.style.zIndex = 5;
 
 		player.endedCallback = () => {
-			if (player.currentPlaylistItem < player.listItems.length) {
-				player.setSrc(player.playlist[++player.currentPlaylistItem]);
+			if (player.playlist[++player.currentPlaylistItem]) {
+				player.setSrc(player.playlist[player.currentPlaylistItem].src);
 				player.load();
 				setTimeout(() => {
 					player.play();
 				}, 200);
+			} else {
+				--player.currentPlaylistItem;
 			}
 		};
 


### PR DESCRIPTION
Now the function used after video reaches end sets only the url as a source for fetching, not the whole object.

Also the function now stops at the correct index. 