### PR TITLE
Fix speed plugin always controlling the first player on the page via …

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -78,6 +78,7 @@
                     <li><a href="postroll.html">Postroll</a></li>
                     <li><a href="preview.html">Preview</a></li>
                     <li><a href="quality.html">Quality</a></li>
+                    <li><a href="speed.html">Speed</a></li>
                     <li><a href="vrview.html">VRView</a></li>
                 </ul>
             </main>

--- a/demo/speed.html
+++ b/demo/speed.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>MediaElement.js 3.0 - Speed Plugin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/5.0.1/mediaelementplayer.css">
+    <link rel="stylesheet" href="../dist/speed/speed.css">
+    <link rel="stylesheet" href="demo.css">
+</head>
+<body>
+<div id="container">
+
+    <h1>Speed Plugin</h1>
+    <p><a href="index.html">Back to Main</a></p>
+
+    <p>This plugin allows the generation of a menu with different video/audio speed.</p>
+
+    <h2>Video Player</h2>
+
+    <div class="media-wrapper">
+        <h3>Video Player 1</h3>
+        <video id="player1" width="750" height="421" controls preload="none" poster="http://mediaelementjs.com/images/big_buck_bunny.jpg">
+            <source type="video/mp4" src="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4">
+        </video>
+        <h3>Video Player 2</h3>
+        <video id="player2" width="750" height="421" controls preload="none" poster="http://mediaelementjs.com/images/big_buck_bunny.jpg">
+            <source type="video/mp4" src="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4">
+        </video>
+    </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/5.0.1/mediaelement-and-player.min.js"></script>
+<script src="../dist/speed/speed.js"></script>
+<script>
+	var mediaElements = document.querySelectorAll('video, audio');
+
+	for (var i = 0, total = mediaElements.length; i < total; i++) {
+		new MediaElementPlayer(mediaElements[i], {
+			features: ['playpause', 'current', 'progress', 'duration', 'speed'],
+		});
+	}
+</script>
+</body>
+</html>

--- a/dist/speed/speed.js
+++ b/dist/speed/speed.js
@@ -100,6 +100,13 @@ Object.assign(MediaElementPlayer.prototype, {
 		    radios = player.speedButton.querySelectorAll('input[type="radio"]'),
 		    labels = player.speedButton.querySelectorAll('.' + t.options.classPrefix + 'speed-selector-label');
 
+		/**
+		 * Store a reference to the radio buttons to prevent a scope bug in keyboard events
+		 * with multiple MediaElement players are on the same page. Otherwise these keyboard
+		 * events would always control the first speed button instance on the page.
+		 */
+		player.speedRadioButtons = radios;
+
 		for (var _i2 = 0, _total2 = inEvents.length; _i2 < _total2; _i2++) {
 			player.speedButton.addEventListener(inEvents[_i2], function () {
 				mejs.Utils.removeClass(player.speedSelector, t.options.classPrefix + 'offscreen');
@@ -154,9 +161,10 @@ Object.assign(MediaElementPlayer.prototype, {
 			action: function action(player, media, key, event) {
 				if (event.key != '<') return;
 
-				for (var _i7 = 0; _i7 < radios.length - 1; _i7++) {
-					if (radios[_i7].checked) {
-						var nextRadio = radios[_i7 + 1];
+				const _radios = player.speedRadioButtons;
+				for (var _i7 = 0; _i7 < _radios.length - 1; _i7++) {
+					if (_radios[_i7].checked) {
+						var nextRadio = _radios[_i7 + 1];
 						nextRadio.dispatchEvent(mejs.Utils.createEvent('click', nextRadio));
 						break;
 					}
@@ -167,9 +175,10 @@ Object.assign(MediaElementPlayer.prototype, {
 			action: function action(player, media, key, event) {
 				if (event.key != '>') return;
 
-				for (var _i8 = 1; _i8 < radios.length; _i8++) {
-					if (radios[_i8].checked) {
-						var prevRadio = radios[_i8 - 1];
+				const _radios = player.speedRadioButtons;
+				for (var _i8 = 1; _i8 < _radios.length; _i8++) {
+					if (_radios[_i8].checked) {
+						var prevRadio = _radios[_i8 - 1];
 						prevRadio.dispatchEvent(mejs.Utils.createEvent('click', prevRadio));
 						break;
 					}


### PR DESCRIPTION
The keyboard controls for the speed plugin (`<` and `>` keys that have been implemented in #134) would always control the first player on a page. This is a problem when multiple players exist on a page. This PR fixes the problem by storing a reference to the radio buttons on the player instance. I have also added a demo page for the plugin that did not exist yet.