### PR TITLE
fix: keyboard controls for source-chooser.js

### DIFF
--- a/dist/source-chooser/source-chooser.js
+++ b/dist/source-chooser/source-chooser.js
@@ -64,7 +64,7 @@ Object.assign(MediaElementPlayer.prototype, {
 			}, 0);
 		});
 
-		player.sourcechooserButton.addEventListener('keydown', function (e) {
+		player.sourcechooserButton.addEventListener('keypress', function (e) {
 
 			function focusNext(dir = 1) {
 				let radioEls = Array.from(player.sourcechooserButton.querySelectorAll('input[type="radio"]'));

--- a/dist/source-chooser/source-chooser.js
+++ b/dist/source-chooser/source-chooser.js
@@ -64,7 +64,7 @@ Object.assign(MediaElementPlayer.prototype, {
 			}, 0);
 		});
 
-		player.sourcechooserButton.addEventListener('keypress', function (e) {
+		player.sourcechooserButton.addEventListener('keydown', function (e) {
 
 			function focusNext(dir = 1) {
 				let radioEls = Array.from(player.sourcechooserButton.querySelectorAll('input[type="radio"]'));


### PR DESCRIPTION
This commit contributes work done for the [Universal Viewer project](https://github.com/UniversalViewer/universalviewer) that fixes broken keyboard controls for the source chooser and also adds arrow key controls.

Apologies for the whitespace fixes making this a little messier, but it does seem to normalize the tabs and spaces.